### PR TITLE
feature: Se Implementó la 1ra versión de la página de detalles de cada match.

### DIFF
--- a/app_objetos_perdidos/lib/pages/list_coincidencias_page.dart
+++ b/app_objetos_perdidos/lib/pages/list_coincidencias_page.dart
@@ -157,7 +157,7 @@ class _ListCoincidenciasPageState extends State<ListCoincidenciasPage> {
                                   }
 
                                   final nivelCoincidencia = snapshot.data ?? 0;
-                                  Color
+                                 Color
                                   porcentajeColor; // color dependiendo del %
 
                                   if (nivelCoincidencia >= 75) {

--- a/app_objetos_perdidos/lib/pages/match_details_page.dart
+++ b/app_objetos_perdidos/lib/pages/match_details_page.dart
@@ -19,6 +19,7 @@ class MatchDetailsPage extends StatefulWidget {
 class _MatchDetailsPageState extends State<MatchDetailsPage> {
   @override
   Widget build(BuildContext context) {
+    Color porcentajeColor;
     // Aquí iría la implementación de la página de detalles de la coincidencia
     return Scaffold(
       appBar: AppBar(
@@ -49,11 +50,23 @@ class _MatchDetailsPageState extends State<MatchDetailsPage> {
               }
 
               final nivelCoincidencia = snapshot.data ?? 0;
+
+              if (nivelCoincidencia >= 75) {
+                porcentajeColor = Colors.green[800]!; // Verde oscuro
+              } else if (nivelCoincidencia >= 50) {
+                porcentajeColor =Colors.green[300]!; // Verde claro
+              } else if (nivelCoincidencia >= 25) {
+                porcentajeColor = Colors.orange; // Naranjo
+              } else {
+                porcentajeColor = Colors.red; // Rojo
+              } 
+
               return Text(
                 'Nivel de Coincidencia: $nivelCoincidencia%',
-                style: const TextStyle(
+                style: TextStyle(
                   fontSize: 20,
                   fontWeight: FontWeight.bold,
+                  foreground: Paint()..color = porcentajeColor,
                 ),
               );
             }),


### PR DESCRIPTION
El administrador ahora puede cliquear en un matching para abrir otra página con los detalles del match, en el cual uno puede ver ambos reportes, como también aceptar o rechazar el matching.

Por ahora, al aceptar, el reporte queda como "encontrado", mientras que al rechazar, no pasa nada.

En ambos casos, no se borran los matching.

(Ya que no tengo el API Key de Gemini, no pude testear si funciona el nivel de coincidencia con está página, en teoría si.)

<img width="586" height="962" alt="image" src="https://github.com/user-attachments/assets/cd066272-a0f6-4794-9bbe-c5dd222bce39" />
