### PR TITLE
feature: Se Implementó la 1ra versión de la página de detalles de cada match.

### DIFF
--- a/app_objetos_perdidos/lib/pages/list_coincidencias_page.dart
+++ b/app_objetos_perdidos/lib/pages/list_coincidencias_page.dart
@@ -157,7 +157,7 @@ class _ListCoincidenciasPageState extends State<ListCoincidenciasPage> {
                                   }
 
                                   final nivelCoincidencia = snapshot.data ?? 0;
-                                  Color
+                                 Color
                                   porcentajeColor; // color dependiendo del %
 
                                   if (nivelCoincidencia >= 75) {

--- a/app_objetos_perdidos/lib/pages/match_details_page.dart
+++ b/app_objetos_perdidos/lib/pages/match_details_page.dart
@@ -19,6 +19,7 @@ class MatchDetailsPage extends StatefulWidget {
 class _MatchDetailsPageState extends State<MatchDetailsPage> {
   @override
   Widget build(BuildContext context) {
+    Color porcentajeColor;
     // Aquí iría la implementación de la página de detalles de la coincidencia
     return Scaffold(
       appBar: AppBar(
@@ -49,11 +50,23 @@ class _MatchDetailsPageState extends State<MatchDetailsPage> {
               }
 
               final nivelCoincidencia = snapshot.data ?? 0;
+
+              if (nivelCoincidencia >= 75) {
+                porcentajeColor = Colors.green[800]!; // Verde oscuro
+              } else if (nivelCoincidencia >= 50) {
+                porcentajeColor =Colors.green[300]!; // Verde claro
+              } else if (nivelCoincidencia >= 25) {
+                porcentajeColor = Colors.orange; // Naranjo
+              } else {
+                porcentajeColor = Colors.red; // Rojo
+              } 
+
               return Text(
                 'Nivel de Coincidencia: $nivelCoincidencia%',
-                style: const TextStyle(
+                style: TextStyle(
                   fontSize: 20,
                   fontWeight: FontWeight.bold,
+                  foreground: Paint()..color = porcentajeColor,
                 ),
               );
             }),


### PR DESCRIPTION
El administrador ahora puede cliquear en un matching para abrir otra página con los detalles del match, en el cual uno puede ver ambos reportes, como también aceptar o rechazar el matching.

Por ahora, al aceptar, el reporte queda como "encontrado", mientras que al rechazar, no pasa nada.

En ambos casos, no se borran los matching.

<img width="588" height="960" alt="image" src="https://github.com/user-attachments/assets/af2e1cb0-b938-485b-b49f-ed1f7afa2d11" />
